### PR TITLE
Finish transfer of repo to libraries org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # @link https://travis-ci.org/
 
 # For use with the MIT Libraries' news integration plugin.
-# @link https://github.com/matt-bernhardt/wp-news-integration
+# @link https://github.com/mitlibraries/mitlib-secrets-widget
 
 # Declare what Travis environment should be used. Specifically, we need the
 # 'precise' environment rather than 'trusty' to get PHP 5.3.

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,19 @@ matrix:
 
   include:
     # Declare versions of PHP to use. Use one decimal max.
-    - php: '5.3'
-      env: PHPCS_BRANCH=2.9.1 PHPCS_SCRIPT=scripts SNIFF=1
+    # We sniff the current and +1 release of PHP, and just run syntax checking
+    # for others.
+    - php: 'nightly'
+    - php: '7.3'
+    - php: '7.2'
+      env: PHPCS_BRANCH=master PHPCS_SCRIPT=bin SNIFF=1
     - php: '7.1'
       env: PHPCS_BRANCH=master PHPCS_SCRIPT=bin SNIFF=1
-    - php: 'nightly'
 
   allow_failures:
     - php: "nightly"
-    - php: "7.1"
+    - php: "7.3"
+    - php: "7.2"
 
 # Use this to prepare the system to install prerequisites or dependencies.
 # e.g. sudo apt-get update.
@@ -43,7 +47,7 @@ before_script:
   - export PHPCS_DIR=/tmp/phpcs
   # Define WordPress Coding Standards
   - export WPCS_DIR=/tmp/wpcs
-  - export WPCS_BRANCH=1.2.0
+  - export WPCS_BRANCH=master
   # Install WordPress Coding Standards (master branch, not develop).
   - if [[ "$SNIFF" == "1" ]]; then git clone -b $WPCS_BRANCH https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
   # Install CodeSniffer for WordPress Coding Standards checks (pre 3.x version).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MIT Libraries Secrets Widget
 
-[![Build Status](https://travis-ci.org/matt-bernhardt/mitlib-secrets-widget.svg)](https://travis-ci.org/matt-bernhardt/mitlib-secrets-widget)
-[![Code Climate](https://codeclimate.com/github/matt-bernhardt/mitlib-secrets-widget/badges/gpa.svg)](https://codeclimate.com/github/matt-bernhardt/mitlib-secrets-widget)
-[![Issue Count](https://codeclimate.com/github/matt-bernhardt/mitlib-secrets-widget/badges/issue_count.svg)](https://codeclimate.com/github/matt-bernhardt/mitlib-secrets-widget)
+[![Build Status](https://travis-ci.org/mitlibraries/mitlib-secrets-widget.svg)](https://travis-ci.org/mitlibraries/mitlib-secrets-widget)
+[![Code Climate](https://codeclimate.com/github/mitlibraries/mitlib-secrets-widget/badges/gpa.svg)](https://codeclimate.com/github/mitlibraries/mitlib-secrets-widget)
+[![Issue Count](https://codeclimate.com/github/mitlibraries/mitlib-secrets-widget/badges/issue_count.svg)](https://codeclimate.com/github/mitlibraries/mitlib-secrets-widget)
 
 This plugin provides an administrative widget that lists defined secrets that are available in that environment.

--- a/codesniffer.mitlib.xml
+++ b/codesniffer.mitlib.xml
@@ -18,11 +18,9 @@
 		<exclude name="WordPress.CodeAnalysis" />
 		<exclude name="WordPress.DB" />
 		<exclude name="WordPress.Files" />
-		<exclude name="WordPress.Functions" />
 		<exclude name="WordPress.NamingConventions" />
 		<exclude name="WordPress.PHP" />
 		<exclude name="WordPress.Utils" />
-		<exclude name="WordPress.Variables" />
 		<exclude name="WordPress.WP" />
 		<exclude name="WordPress.WhiteSpace" />
 	</rule>

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "matt-bernhardt/mitlib-secrets-widget",
+    "name": "mitlibraries/mitlib-secrets-widget",
     "description": "A WordPress plugin that provides an administrative widget to list available secrets",
     "type": "wordpress-plugin",
     "license": "GPLv2",

--- a/mitlib-secrets-widget.php
+++ b/mitlib-secrets-widget.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: MITlib Secrets Widget
- * Plugin URI: https://github.com/matt-bernhardt/mitlib-secrets-widget
+ * Plugin URI: https://github.com/mitlibraries/mitlib-secrets-widget
  * Description: A plugin to list the defined secrets (keys, not their values) coming from Pantheon's Terminus Secrets plugin
  * Version: 0.1.2
  * Author: Matt Bernhardt
@@ -10,7 +10,7 @@
  *
  * @package MITlib Secrets Widget
  * @author Matt Bernhardt
- * @link https://github.com/matt-bernhardt/mitlib-secrets-widget
+ * @link https://github.com/mitlibraries/mitlib-secrets-widget
  */
 
 /**


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
There are a few configuration files that need to be updated as part of moving this repo from my account to the Libraries. The most relevant change is to `composer.json`. Along the way this also updates the Travis configuration to that used by other projects.

#### Helpful background context (if appropriate)
I built this plugin a year ago when we were evaluating various CMS projects, but never added it to the org because at the time we didn't have any production WP projects on Pantheon. Now that we do, it makes sense to move this.

#### To review
Review is not possible, in this case, unfortunately. Or more specifically, this branch is not easily reference-able by Composer because the repo name and the values in `composer.json` diverge. Which is precisely the problem that this PR aims to fix.

**Note to reviewers**
Travis is failing on this because there is one line (line 66) on the class file that references a PHP super global while loading the secrets file. There's probably a way around this, but the method used here is the one that Pantheon recommends - and is seen here: https://github.com/MITLibraries/mitlib-wp-demo/blob/master/web/wp-config.php#L171-L173

Feel free to double check me on this, and push back if you think this needs closed now. At the moment, I'm treating this as existing technical debt.

#### Requires new or updated plugins, themes, or libraries?
NOT NOW (if this was already being used by a site, we would need to update the site after this change)

#### Requires change to deploy process?
NO
